### PR TITLE
Improve profile design and tea form

### DIFF
--- a/cup_and_leaf/tea_collection/forms.py
+++ b/cup_and_leaf/tea_collection/forms.py
@@ -128,6 +128,12 @@ class UserEditForm(forms.ModelForm):
             "last_name": "Фамилия",
             "email": "Email",
         }
+        help_texts = {
+            "username": (
+                "Обязательное. Не более 150 символов. "
+                "Используйте только буквы, цифры и символы @/./+/-/_."
+            )
+        }
 
 
 class TeaPostForm(forms.ModelForm):
@@ -149,7 +155,9 @@ class TeaPostForm(forms.ModelForm):
             ),
             "type": forms.Select(attrs={"class": "form-control"}),
             "origin": forms.Select(attrs={"class": "form-control"}),
-            "production_year": forms.Select(attrs={"class": "form-control"}),
+            "production_year": forms.NumberInput(
+                attrs={"class": "form-control", "placeholder": "Год производства"}
+            ),
             "tea_grade": forms.Select(attrs={"class": "form-control"}),
             "appearance": forms.Textarea(
                 attrs={

--- a/cup_and_leaf/templates/tea_collection/profile.html
+++ b/cup_and_leaf/templates/tea_collection/profile.html
@@ -129,7 +129,17 @@
 
 .card-header {
     border-bottom: 1px solid rgba(0,0,0,.125);
-    background-color: rgba(255,255,255,.8);
+    background-color: #4a6741;
+    padding: 1rem 1.25rem;
+}
+
+.card-header h3 {
+    color: #ffffff;
+}
+
+.card-header a {
+    text-decoration: none;
+    color: inherit;
 }
 
 .list-group-item {

--- a/cup_and_leaf/templates/tea_collection/profile_edit.html
+++ b/cup_and_leaf/templates/tea_collection/profile_edit.html
@@ -30,7 +30,7 @@
 
                         <div class="d-flex justify-content-between">
                             <button type="submit" class="btn btn-primary">Сохранить изменения</button>
-                            <a href="{% url 'tea_collection:tea_post_list' %}" class="btn-outline">Отмена</a>
+                            <a href="{% url 'tea_collection:profile' %}" class="btn-reset">Отмена</a>
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
## Summary
- translate username help text and adjust profile edit cancel link
- tweak profile headers style
- use number input for production year

## Testing
- `python cup_and_leaf/manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6850143c4d6883239b56465ab6c78d1d