### PR TITLE
Fix tea creation flow

### DIFF
--- a/cup_and_leaf/tea_collection/models.py
+++ b/cup_and_leaf/tea_collection/models.py
@@ -117,7 +117,8 @@ class TeaPost(models.Model):
         return self.title
 
     def get_absolute_url(self):
-        return reverse("tea_collection:tea_post_detail", kwargs={"pk": self.pk})
+        """Return the URL to this tea post's detail page."""
+        return reverse("tea_collection:tea_detail", kwargs={"pk": self.pk})
 
     def get_fields(self):
         """Возвращает список полей модели с их значениями и метаданными"""

--- a/cup_and_leaf/tea_collection/tests/test_create_post.py
+++ b/cup_and_leaf/tea_collection/tests/test_create_post.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from tea_collection.models import TeaPost
+
+
+class TeaPostCreateTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="creator", password="pass")
+
+    def test_create_post(self):
+        self.client.login(username="creator", password="pass")
+        url = reverse("tea_collection:tea_create")
+        data = {
+            "title": "New Tea",
+            "type": "green",
+            "origin": "china",
+            "production_year": 2024,
+            "tea_grade": "first",
+            "appearance": "leaves",
+            "description": "tasty",
+        }
+        response = self.client.post(url, data)
+        self.assertRedirects(response, reverse("tea_collection:index"))
+        self.assertTrue(TeaPost.objects.filter(title="New Tea").exists())


### PR DESCRIPTION
## Summary
- fix `get_absolute_url` to point to the correct detail route
- add a test ensuring tea posts can be created

## Testing
- `python cup_and_leaf/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685065b8a1cc83239a82ebe4a71e9596