### PR TITLE
Fix logout GET method

### DIFF
--- a/cup_and_leaf/tea_collection/tests/test_logout.py
+++ b/cup_and_leaf/tea_collection/tests/test_logout.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+
+class LogoutViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="u", password="p")
+
+    def test_logout_via_get(self):
+        self.client.login(username="u", password="p")
+        response = self.client.get(reverse("logout"))
+        self.assertRedirects(response, reverse("tea_collection:index"))
+        self.assertNotIn("_auth_user_id", self.client.session)

--- a/cup_and_leaf/tea_collection/views.py
+++ b/cup_and_leaf/tea_collection/views.py
@@ -12,7 +12,7 @@ from django.views.generic import (
     ListView,
     UpdateView,
 )
-from django.contrib.auth import login
+from django.contrib.auth import login, logout
 from django.contrib import messages
 from django.contrib.auth.views import LoginView
 
@@ -248,3 +248,9 @@ def search_tea(request):
         "query": request.GET.get("query", ""),
     }
     return render(request, "tea_collection/search_results.html", context)
+
+
+def logout_view(request):
+    """Log out the current user on GET or POST and redirect to the index."""
+    logout(request)
+    return redirect("tea_collection:index")

--- a/cup_and_leaf/tea_core/urls.py
+++ b/cup_and_leaf/tea_core/urls.py
@@ -3,8 +3,11 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 
+from tea_collection.views import logout_view
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("auth/logout/", logout_view, name="logout"),
     path("", include("tea_collection.urls")),
     path("auth/", include("django.contrib.auth.urls")),
     path("pages/", include("pages.urls")),


### PR DESCRIPTION
## Summary
- add GET-compatible logout view
- wire logout view before default auth urls
- test logout view

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685067814598832394ddd98f5f0d46db