### PR TITLE
Fix email login

### DIFF
--- a/cup_and_leaf/tea_collection/forms.py
+++ b/cup_and_leaf/tea_collection/forms.py
@@ -104,6 +104,18 @@ class CustomAuthenticationForm(AuthenticationForm):
             raise forms.ValidationError("Пользователь с таким email не найден.")
         return email
 
+    def clean(self):
+        """Authenticate using the user's email address."""
+        email = self.cleaned_data.get("username")
+        if email:
+            try:
+                user = User.objects.get(email=email)
+                self.cleaned_data["username"] = user.username
+            except User.DoesNotExist:
+                # Ошибка будет обработана в clean_username
+                pass
+        return super().clean()
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["username"].label = "Email"

--- a/cup_and_leaf/tea_collection/views.py
+++ b/cup_and_leaf/tea_collection/views.py
@@ -167,15 +167,6 @@ class CustomLoginView(LoginView):
     form_class = CustomAuthenticationForm
     template_name = "registration/login.html"
 
-    def form_valid(self, form):
-        email = form.cleaned_data.get("username")
-        try:
-            user = User.objects.get(email=email)
-            form.cleaned_data["username"] = user.username
-        except User.DoesNotExist:
-            pass
-        return super().form_valid(form)
-
 
 def register(request):
     if request.method == "POST":


### PR DESCRIPTION
## Summary
- authenticate users in `CustomAuthenticationForm` by email
- simplify `CustomLoginView`

## Testing
- `python cup_and_leaf/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68506e791d008323af6e6f824c4f1c4a