### PR TITLE
Fix login path and cleanup

### DIFF
--- a/cup_and_leaf/tea_collection/models.py
+++ b/cup_and_leaf/tea_collection/models.py
@@ -124,12 +124,12 @@ class TeaPost(models.Model):
         """Возвращает список полей модели с их значениями и метаданными"""
         return [
             {
-                'name': field.name,
-                'value': getattr(self, field.name),
-                'verbose_name': field.verbose_name,
+                "name": field.name,
+                "value": getattr(self, field.name),
+                "verbose_name": field.verbose_name,
             }
             for field in self._meta.fields
-            if field.name != 'id'  # Исключаем поле id
+            if field.name != "id"  # Исключаем поле id
         ]
 
 

--- a/cup_and_leaf/tea_collection/views.py
+++ b/cup_and_leaf/tea_collection/views.py
@@ -24,7 +24,7 @@ from .forms import (
     CustomAuthenticationForm,
     TeaPostForm,
 )
-from .models import TeaPost, TeaComment, User
+from .models import TeaPost, TeaComment
 from .utils import send_welcome_email
 
 

--- a/cup_and_leaf/tea_core/settings.py
+++ b/cup_and_leaf/tea_core/settings.py
@@ -18,9 +18,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 DEBUG = os.getenv("DEBUG", "False") == "True"
 
 ALLOWED_HOSTS = (
-    os.getenv("ALLOWED_HOSTS", "").split(",")
-    if os.getenv("ALLOWED_HOSTS")
-    else []
+    os.getenv("ALLOWED_HOSTS", "").split(",") if os.getenv("ALLOWED_HOSTS") else []
 )
 
 # Application definition
@@ -68,9 +66,7 @@ WSGI_APPLICATION = "tea_core.wsgi.application"
 # Database
 DATABASES = {
     "default": {
-        "ENGINE": os.getenv(
-            "DB_ENGINE", "django.db.backends.sqlite3"
-        ),
+        "ENGINE": os.getenv("DB_ENGINE", "django.db.backends.sqlite3"),
         "NAME": os.getenv("DB_NAME", BASE_DIR / "db.sqlite3"),
     }
 }
@@ -99,9 +95,7 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = os.getenv("STATIC_URL", "static/")
-STATIC_ROOT = os.getenv(
-    "STATIC_ROOT", os.path.join(BASE_DIR, "staticfiles")
-)
+STATIC_ROOT = os.getenv("STATIC_ROOT", os.path.join(BASE_DIR, "staticfiles"))
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),
 ]

--- a/cup_and_leaf/tea_core/urls.py
+++ b/cup_and_leaf/tea_core/urls.py
@@ -3,11 +3,12 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 
-from tea_collection.views import logout_view
+from tea_collection.views import CustomLoginView, logout_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("auth/logout/", logout_view, name="logout"),
+    path("auth/login/", CustomLoginView.as_view(), name="login"),
     path("", include("tea_collection.urls")),
     path("auth/", include("django.contrib.auth.urls")),
     path("pages/", include("pages.urls")),


### PR DESCRIPTION
## Summary
- fix order of login url so `/auth/login/` uses custom login view
- remove unused User import
- format settings and models with black

## Testing
- `ruff check .`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_68506fd589ec8323ae1b35d5e29703ae